### PR TITLE
Delete duplicated misspelt file.

### DIFF
--- a/destination_recieve.py
+++ b/destination_recieve.py
@@ -1,6 +1,0 @@
-import send_text, sessions
-def destination(number, destination):
-	#Stuff to store the number and origin
-	send_text.text(number, 'Hang in there!')
-	sessions.add_destination(nnumber, destination)
-	return


### PR DESCRIPTION
Deletes destination_recieve.py, which is a misspelt duplicate of destination_receive.py.
